### PR TITLE
fix clearing phone mask on enter symbol in the middle

### DIFF
--- a/phoneinput.js
+++ b/phoneinput.js
@@ -34,8 +34,9 @@ document.addEventListener("DOMContentLoaded", function () {
         if (input.value.length != selectionStart) {
             // Editing in the middle of input, not last symbol
             if (e.data && /\D/g.test(e.data)) {
-                // Attempt to input non-numeric symbol
-                input.value = inputNumbersValue;
+                input.value = input.value.replace(e.data, '');
+                input.selectionStart = selectionStart - 1;
+                input.selectionEnd = input.selectionStart;
             }
             return;
         }


### PR DESCRIPTION
Исправил сброс маски при вводе символа в середину. Каретка остается в том же месте.
Хоть в видео это поведение считалось нормой, это достаточно плохой UX, когда слетает форматирование из-за случайного ввода символа. 